### PR TITLE
Refactor tests to use pytest, mirroring updates in progress to Faker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ activate:
 	pipenv shell
 
 test:
-	pipenv run coverage run -m unittest tests/*
+	pipenv run pytest --cov=faker_credit_score
 
 coverage:
 	pipenv run coveralls

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-coverage = "*"
 faker = "*"
 python-coveralls = "*"
+pytest = "*"
+pytest-cov = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e428a709143225222d75051d971be024e9c5c2c5bd57261c402e21796bead25b"
+            "sha256": "6832dd145565f8c0aa2dffee4f3a8acff42691a06aa0e1b19fa0268d86f30d7f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -15,6 +15,14 @@
     },
     "default": {},
     "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.2.0"
+        },
         "certifi": {
             "hashes": [
                 "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
@@ -66,16 +74,16 @@
                 "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
                 "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==5.3"
         },
         "faker": {
             "hashes": [
-                "sha256:075a95ac4c95765370919d787dcd958acfaea635005ad5af4d926cb0973800db",
-                "sha256:80bab8d46035a7393de827210c5d39c17109d3346d131946bde622137120c496"
+                "sha256:6d57066eb7a0dd089f85cee99d0e75a7dcd86d74f9d5af7ccc4ace204b994cd6",
+                "sha256:a69c06e1f160e14a6da96ef6bff98e7b931f8e30d4e4e8ba399aff859965bb19"
             ],
             "index": "pypi",
-            "version": "==4.1.3"
+            "version": "==4.4.0"
         },
         "idna": {
             "hashes": [
@@ -84,6 +92,61 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
+                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+            ],
+            "version": "==1.0.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.4"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.9.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:1cd09785c0a50f9af72220dd12aa78cfa49cbffc356c61eab009ca189e018a33",
+                "sha256:d010e24666435b39a4cf48740b039885642b6c273a3f77be3e7e03554d2806b7"
+            ],
+            "index": "pypi",
+            "version": "==6.1.0"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191",
+                "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
+            ],
+            "index": "pypi",
+            "version": "==2.10.1"
         },
         "python-coveralls": {
             "hashes": [
@@ -98,7 +161,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "pyyaml": {
@@ -130,7 +193,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "text-unidecode": {
@@ -139,6 +202,13 @@
                 "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"
             ],
             "version": "==1.3"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "version": "==0.10.1"
         },
         "urllib3": {
             "hashes": [

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Execute unit tests and calculate code coverage like so:
 
 .. code:: bash
 
-    $ coverage run -m unittest tests/*
+    $ pytest --cov=faker_credit_score
     ..............
     ----------------------------------------------------------------------
     Ran 14 tests in 0.406s

--- a/faker_credit_score/__version__.py
+++ b/faker_credit_score/__version__.py
@@ -1,4 +1,4 @@
 """Package version."""
-VERSION = (0, 3, 1)
+VERSION = (0, 3, 2)
 
 __version__ = ".".join(map(str, VERSION))

--- a/tests/test_faker_credit_score.py
+++ b/tests/test_faker_credit_score.py
@@ -1,100 +1,114 @@
 #  -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
-
-import unittest
+import pytest
 import re
 
-from faker import Faker
-from faker_credit_score import CreditScore
+
+@pytest.fixture
+def fake():
+    from faker import Faker
+    from faker_credit_score import CreditScore
+
+    Faker.seed(0)
+    fake = Faker("en_US")
+    fake.add_provider(CreditScore)
+
+    return fake
 
 
-class TestEnUS(unittest.TestCase):
-    def setUp(self):
-        self.fake = Faker("en_US")
-        self.fake.add_provider(CreditScore)
-        Faker.seed(0)
+def test_failure_scenario_credit_score_nonexistent_provider(fake):
+    with pytest.raises(KeyError):
+        fake.credit_score("nonexistent")
 
-    def test_failure_scenario_credit_score_nonexistent_provider(self):
-        with self.assertRaises(KeyError):
-            credit_score = self.fake.credit_score("nonexistent")
 
-    def test_failure_scenario_credit_score_provider_nonexistent_provider(self):
-        with self.assertRaises(KeyError):
-            credit_score_provider = self.fake.credit_score_provider("nonexistent")
+def test_failure_scenario_credit_score_provider_nonexistent_provider(fake):
+    with pytest.raises(KeyError):
+        fake.credit_score_provider("nonexistent")
 
-    def test_failure_scenario_credit_score_name_nonexistent_provider(self):
-        with self.assertRaises(KeyError):
-            credit_score_name = self.fake.credit_score_name("nonexistent")
 
-    def test_failure_scenario_credit_score_full_nonexistent_provider(self):
-        with self.assertRaises(KeyError):
-            credit_score_full = self.fake.credit_score_full("nonexistent")
+def test_failure_scenario_credit_score_name_nonexistent_provider(fake):
+    with pytest.raises(KeyError):
+        fake.credit_score_name("nonexistent")
 
-    def test_random_credit_score(self):
-        for _ in range(100):
-            credit_score = self.fake.credit_score()
-            assert 300 <= credit_score <= 850
 
-    def test_credit_score_of_a_specific_type(self):
-        for _ in range(100):
-            credit_score = self.fake.credit_score("fico8")
-            assert 300 <= credit_score <= 850
+def test_failure_scenario_credit_score_full_nonexistent_provider(fake):
+    with pytest.raises(KeyError):
+        fake.credit_score_full("nonexistent")
 
-    def test_random_credit_score_provider(self):
-        for _ in range(100):
-            provider = self.fake.credit_score_provider()
-            assert provider in ("FICO", "Experian", "Equifax", "TransUnion")
 
-    def test_credit_score_provider_of_a_specific_type(self):
-        for _ in range(100):
-            provider = self.fake.credit_score_provider("fico5")
-            assert provider == "Equifax"
+def test_random_credit_score(fake):
+    for _ in range(100):
+        credit_score = fake.credit_score()
+        assert 300 <= credit_score <= 850
 
-    def test_random_credit_score_name(self):
-        for _ in range(100):
-            name = self.fake.credit_score_name()
-            assert name in (
-                "FICO Score 8",
-                "Equifax Beacon 5.0",
-                "Experian/Fair Isaac Risk Model V2SM",
-                "TransUnion FICO Risk Score, Classic 04",
-                "VantageScore 3.0",
-                "FICO Score 10",
-                "FICO Score 10 T",
-            )
 
-    def test_credit_score_name_of_a_specific_type_fico5(self):
-        for _ in range(100):
-            name = self.fake.credit_score_name("fico5")
-            assert name == "Equifax Beacon 5.0"
+def test_credit_score_of_a_specific_type(fake):
+    for _ in range(100):
+        credit_score = fake.credit_score("fico8")
+        assert 300 <= credit_score <= 850
 
-    def test_credit_score_name_of_a_specific_type_fico2(self):
-        for _ in range(100):
-            name = self.fake.credit_score_name("fico2")
-            assert name == "Experian/Fair Isaac Risk Model V2SM"
 
-    def test_credit_score_name_of_a_specific_type_fico4(self):
-        for _ in range(100):
-            name = self.fake.credit_score_name("fico4")
-            assert name == "TransUnion FICO Risk Score, Classic 04"
+def test_random_credit_score_provider(fake):
+    for _ in range(100):
+        provider = fake.credit_score_provider()
+        assert provider in ("FICO", "Experian", "Equifax", "TransUnion")
 
-    def test_random_credit_score_full(self):
-        """ Output looks like this (provider, model, and credit score are random):
-        Equifax Beacon 5.0
-        Equifax
-        660
-        """
-        for _ in range(100):
-            output = self.fake.credit_score_full()
-            assert re.match(r".+\n.+\n\d{3}\n", output)
 
-    def test_credit_score_full_of_a_specific_type(self):
-        """ Output looks like this (credit score is random):
-        Equifax Beacon 5.0
-        Equifax
-        660
-        """
-        for _ in range(100):
-            output = self.fake.credit_score_full("fico5")
-            assert re.match(r"Equifax Beacon 5\.0\nEquifax\n\d{3}\n", output)
+def test_credit_score_provider_of_a_specific_type(fake):
+    for _ in range(100):
+        provider = fake.credit_score_provider("fico5")
+        assert provider == "Equifax"
+
+
+def test_random_credit_score_name(fake):
+    for _ in range(100):
+        name = fake.credit_score_name()
+        assert name in (
+            "FICO Score 8",
+            "Equifax Beacon 5.0",
+            "Experian/Fair Isaac Risk Model V2SM",
+            "TransUnion FICO Risk Score, Classic 04",
+            "VantageScore 3.0",
+            "FICO Score 10",
+            "FICO Score 10 T",
+        )
+
+
+def test_credit_score_name_of_a_specific_type_fico5(fake):
+    for _ in range(100):
+        name = fake.credit_score_name("fico5")
+        assert name == "Equifax Beacon 5.0"
+
+
+def test_credit_score_name_of_a_specific_type_fico2(fake):
+    for _ in range(100):
+        name = fake.credit_score_name("fico2")
+        assert name == "Experian/Fair Isaac Risk Model V2SM"
+
+
+def test_credit_score_name_of_a_specific_type_fico4(fake):
+    for _ in range(100):
+        name = fake.credit_score_name("fico4")
+        assert name == "TransUnion FICO Risk Score, Classic 04"
+
+
+def test_random_credit_score_full(fake):
+    """ Output looks like this (provider, model, and credit score are random):
+    Equifax Beacon 5.0
+    Equifax
+    660
+    """
+    for _ in range(100):
+        output = fake.credit_score_full()
+        assert re.match(r".+\n.+\n\d{3}\n", output)
+
+
+def test_credit_score_full_of_a_specific_type(fake):
+    """ Output looks like this (credit score is random):
+    Equifax Beacon 5.0
+    Equifax
+    660
+    """
+    for _ in range(100):
+        output = fake.credit_score_full("fico5")
+        assert re.match(r"Equifax Beacon 5\.0\nEquifax\n\d{3}\n", output)


### PR DESCRIPTION
- Keep package testing style in sync
  - Uses fixture to avoid need for class instantiation
  - Removes a level of indentation
  - Allow pyright to lint conditional creation
- Cascade updates to `Makefile`