### PR TITLE
maint: update Python matrix to 3.10-3.14, align CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,20 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # hatch-vcs needs tags
 
-      - name: Setup Python
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        run: pip install uv
 
       - name: Sync deps (creates .venv, installs project + dev group)
         run: uv sync
@@ -50,17 +52,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'   # stable builder
-
-      - name: Install uv
-        run: pip install uv
+          python-version: '3.12'
 
       - name: Build artifacts
         run: uv build --sdist --wheel
@@ -79,17 +81,17 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-
-      - name: Install uv
-        run: pip install uv
+          python-version: '3.12'
 
       - name: Build artifacts (repeat for safety)
         run: uv build --sdist --wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,38 +10,32 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [‘3.10’, ‘3.11’, ‘3.12’, ‘3.13’, ‘3.14’]
     env:
       PYTHONUTF8: 1
     steps:
-      # 1. Check out the repository
       - uses: actions/checkout@v5
 
-      # 2. Install uv and enable caching of its package cache.
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-          # Pin uv for reproducibility, e.g. version: "0.9.0"
 
-      # 3. Install Python (using GitHub’s cache).  You can choose any version ≥3.9.
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
-      # 4. Sync dependencies from uv.lock.  The --dev flag ensures dev deps
-      #    like pytest-cov are installed
       - name: Install project dependencies
         run: uv sync --locked --all-extras --dev
 
-      # 5. Run tests and produce coverage.xml.  The uv run command automatically
-      #    activates the environment before running pytest
       - name: Run tests with coverage
-        run: |
-          uv run pytest --cov=faker_credit_score --cov-report=xml
+        run: uv run pytest --cov=faker_credit_score --cov-report=xml
 
-      # 6. Upload coverage to Coveralls.  The GITHUB_TOKEN authenticates the upload
       - name: Upload coverage to Coveralls
+        if: matrix.python-version == ‘3.12’
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Adds fake credit score data generation to Faker Python package."
 readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { file = "LICENSE" }
 authors = [{ name = "Cory Donnelly" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
## Summary

- Drop EOL Python 3.9 from `requires-python` and both CI matrices
- Add Python 3.14 to test and release workflows
- Add multi-version test matrix to `test.yml` (was only testing 3.11)
- Standardize both workflows on `actions/checkout@v5` and `astral-sh/setup-uv@v6` (release.yml was using `@v4` and `pip install uv`)
- Upload Coveralls coverage from a single matrix entry (3.12) to avoid duplicate uploads

## Changes

| Before | After |
|--------|-------|
| `requires-python = ">=3.9"` | `requires-python = ">=3.10"` |
| test.yml: Python 3.11 only | test.yml: 3.10, 3.11, 3.12, 3.13, 3.14 |
| release.yml: 3.9–3.13 | release.yml: 3.10–3.14 |
| release.yml: `checkout@v4`, `pip install uv` | release.yml: `checkout@v5`, `astral-sh/setup-uv@v6` |

## Test plan

- [ ] CI matrix runs successfully across all 5 Python versions
- [ ] Coveralls upload succeeds from single matrix entry
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)