### PR TITLE
docs: fix project URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/crd/faker-credit-score"
-Repository = "https://github.com/crd/faker-credit-score"
+Homepage = "https://github.com/crd/faker_credit_score"
+Repository = "https://github.com/crd/faker_credit_score"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Fix Homepage and Repository URLs: `faker-credit-score` → `faker_credit_score`
- Current URLs on PyPI point to a non-existent GitHub repo

Will take effect on next PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)