### PR TITLE
feat: add credit_score_profile() for correlated multi-bureau scores

### DIFF
--- a/faker_credit_score/__init__.py
+++ b/faker_credit_score/__init__.py
@@ -58,6 +58,8 @@ class Provider(BaseProvider):
     # Add alias for FICO to map to FICO 8
     credit_score_types["fico"] = credit_score_types["fico8"]
 
+    profile_jitter = 25
+
     credit_score_tiers = OrderedDict([
         ("poor", (300, 579)),
         ("fair", (580, 669)),
@@ -156,7 +158,7 @@ class Provider(BaseProvider):
 
         results = {}
         for provider in selected:
-            jitter = self.random_int(-25, 25)
+            jitter = self.random_int(-self.profile_jitter, self.profile_jitter)
             score = max(model_low, min(model_high, base_score + jitter))
             results[provider] = CreditScoreResult(
                 name=model.name,

--- a/faker_credit_score/__init__.py
+++ b/faker_credit_score/__init__.py
@@ -122,16 +122,16 @@ class Provider(BaseProvider):
 
         # Determine which providers to generate scores for
         if providers is not None:
-            requested = {p.lower() for p in providers}
             available_lower = {p.lower(): p for p in model.providers}
-            invalid = requested - set(available_lower)
+            requested_lower = [p.lower() for p in providers]
+            invalid = set(requested_lower) - set(available_lower)
             if invalid:
                 raise ValueError(
                     f"Provider(s) {', '.join(sorted(invalid))} not available "
                     f"for '{model.name}'. "
                     f"Available: {', '.join(model.providers)}"
                 )
-            selected = [available_lower[r] for r in requested]
+            selected = [available_lower[p] for p in requested_lower]
         else:
             selected = list(model.providers)
 

--- a/faker_credit_score/__init__.py
+++ b/faker_credit_score/__init__.py
@@ -108,6 +108,64 @@ class Provider(BaseProvider):
             score=self.credit_score(credit_score_summary, tier=tier),
         )
 
+    def credit_score_profile(self, score_type=None, providers=None, tier=None):
+        """Returns correlated credit scores across bureaus for the same person.
+
+        Generates a base score and applies small per-bureau jitter (±25 points)
+        to simulate realistic cross-bureau variance. Individual bureau scores
+        may drift across tier boundaries.
+
+        Returns a dict mapping provider name to CreditScoreResult.
+        """
+        model = self._credit_score_type(score_type)
+        model_low, model_high = model.score_range
+
+        # Determine which providers to generate scores for
+        if providers is not None:
+            requested = {p.lower() for p in providers}
+            available_lower = {p.lower(): p for p in model.providers}
+            invalid = requested - set(available_lower)
+            if invalid:
+                raise ValueError(
+                    f"Provider(s) {', '.join(sorted(invalid))} not available "
+                    f"for '{model.name}'. "
+                    f"Available: {', '.join(model.providers)}"
+                )
+            selected = [available_lower[r] for r in requested]
+        else:
+            selected = list(model.providers)
+
+        # Calculate effective range for the base score
+        base_low, base_high = model_low, model_high
+        if tier is not None:
+            if tier not in self.credit_score_tiers:
+                raise ValueError(
+                    f"Unknown tier '{tier}'. "
+                    f"Valid tiers: {', '.join(self.credit_score_tiers)}"
+                )
+            tier_low, tier_high = self.credit_score_tiers[tier]
+            base_low = max(base_low, tier_low)
+            base_high = min(base_high, tier_high)
+            if base_low > base_high:
+                raise ValueError(
+                    f"Tier '{tier}' has no valid scores for "
+                    f"score type '{model.name}'"
+                )
+
+        base_score = self.random_int(base_low, base_high)
+
+        results = {}
+        for provider in selected:
+            jitter = self.random_int(-25, 25)
+            score = max(model_low, min(model_high, base_score + jitter))
+            results[provider] = CreditScoreResult(
+                name=model.name,
+                provider=provider,
+                score=score,
+            )
+
+        return results
+
     def credit_score_tier(self, score=None):
         """Returns a credit score tier.
 

--- a/tests/test_faker_credit_score.py
+++ b/tests/test_faker_credit_score.py
@@ -299,8 +299,9 @@ def test_credit_score_profile_with_tier(fake):
     for _ in range(100):
         profile = fake.credit_score_profile(score_type="fico8", tier="poor")
         for result in profile.values():
-            # Base score is in poor range; jitter may push slightly outside
-            assert 275 <= result.score <= 604  # 300±25 to 579±25
+            # Base score is in poor range (300-579); jitter may push up but
+            # model clamp prevents going below 300
+            assert 300 <= result.score <= 604
 
 
 def test_credit_score_profile_with_tier_and_model(fake):
@@ -344,3 +345,27 @@ def test_credit_score_profile_scores_within_model_range(fake):
         profile = fake.credit_score_profile(score_type="fico5")
         for result in profile.values():
             assert 334 <= result.score <= 818
+
+
+def test_credit_score_profile_empty_providers(fake):
+    """Empty providers list returns an empty dict."""
+    assert fake.credit_score_profile(score_type="fico8", providers=[]) == {}
+
+
+def test_credit_score_profile_duplicate_providers(fake):
+    """Duplicate provider names are preserved (one entry per request)."""
+    profile = fake.credit_score_profile(
+        score_type="fico8", providers=["Equifax", "equifax"]
+    )
+    # Both resolve to "Equifax" -- dict deduplicates naturally
+    assert set(profile.keys()) == {"Equifax"}
+
+
+def test_credit_score_profile_provider_filter_with_tier(fake):
+    """Provider filter combined with tier constraint."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(
+            score_type="fico8", providers=["Equifax"], tier="poor"
+        )
+        assert set(profile.keys()) == {"Equifax"}
+        assert 300 <= profile["Equifax"].score <= 604

--- a/tests/test_faker_credit_score.py
+++ b/tests/test_faker_credit_score.py
@@ -296,21 +296,28 @@ def test_credit_score_profile_nonexistent_score_type(fake):
 
 def test_credit_score_profile_with_tier(fake):
     """Tier constrains scores to the right ballpark."""
+    from faker_credit_score import CreditScore
+    jitter = CreditScore.profile_jitter
+    model_low = CreditScore.credit_score_types["fico8"].score_range[0]
+    tier_high = CreditScore.credit_score_tiers["poor"][1]
     for _ in range(100):
         profile = fake.credit_score_profile(score_type="fico8", tier="poor")
         for result in profile.values():
-            # Base score is in poor range (300-579); jitter may push up but
-            # model clamp prevents going below 300
-            assert 300 <= result.score <= 604
+            # Base is in poor range; jitter may push up, model clamp prevents below model_low
+            assert model_low <= result.score <= tier_high + jitter
 
 
 def test_credit_score_profile_with_tier_and_model(fake):
     """Combined tier and model constraints work correctly."""
+    from faker_credit_score import CreditScore
+    jitter = CreditScore.profile_jitter
+    model_low, model_high = CreditScore.credit_score_types["fico5"].score_range
+    tier_low = CreditScore.credit_score_tiers["exceptional"][0]
     for _ in range(100):
         profile = fake.credit_score_profile(score_type="fico5", tier="exceptional")
         assert set(profile.keys()) == {"Equifax"}
-        # fico5 range 334-818, exceptional 800-850 → base 800-818, jitter clamped to model
-        assert 775 <= profile["Equifax"].score <= 818
+        # base 800-818, jitter may push down but clamp to model range
+        assert max(model_low, tier_low - jitter) <= profile["Equifax"].score <= model_high
 
 
 def test_credit_score_profile_invalid_tier(fake):
@@ -332,11 +339,13 @@ def test_credit_score_profile_tier_no_overlap(fake):
 
 
 def test_credit_score_profile_scores_correlated(fake):
-    """All scores in a profile should be within 50 points of each other."""
+    """All scores in a profile should be within 2x jitter of each other."""
+    from faker_credit_score import CreditScore
+    max_spread = CreditScore.profile_jitter * 2
     for _ in range(100):
         profile = fake.credit_score_profile(score_type="fico8")
         scores = [r.score for r in profile.values()]
-        assert max(scores) - min(scores) <= 50
+        assert max(scores) - min(scores) <= max_spread
 
 
 def test_credit_score_profile_scores_within_model_range(fake):
@@ -363,9 +372,13 @@ def test_credit_score_profile_duplicate_providers(fake):
 
 def test_credit_score_profile_provider_filter_with_tier(fake):
     """Provider filter combined with tier constraint."""
+    from faker_credit_score import CreditScore
+    jitter = CreditScore.profile_jitter
+    model_low = CreditScore.credit_score_types["fico8"].score_range[0]
+    tier_high = CreditScore.credit_score_tiers["poor"][1]
     for _ in range(100):
         profile = fake.credit_score_profile(
             score_type="fico8", providers=["Equifax"], tier="poor"
         )
         assert set(profile.keys()) == {"Equifax"}
-        assert 300 <= profile["Equifax"].score <= 604
+        assert model_low <= profile["Equifax"].score <= tier_high + jitter

--- a/tests/test_faker_credit_score.py
+++ b/tests/test_faker_credit_score.py
@@ -229,3 +229,118 @@ def test_credit_score_full_with_tier_and_score_type(fake):
         assert result.name == "Equifax Beacon 5.0"
         assert result.provider == "Equifax"
         assert 334 <= result.score <= 579
+
+
+# --- credit_score_profile tests ---
+
+
+def test_credit_score_profile_default(fake):
+    """Default profile returns a dict with CreditScoreResult per provider."""
+    from faker_credit_score import CreditScoreResult
+    for _ in range(100):
+        profile = fake.credit_score_profile()
+        assert isinstance(profile, dict)
+        assert len(profile) >= 1
+        for provider, result in profile.items():
+            assert isinstance(result, CreditScoreResult)
+            assert result.provider == provider
+
+
+def test_credit_score_profile_specific_model(fake):
+    """FICO 8 profile returns all three bureaus."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(score_type="fico8")
+        assert set(profile.keys()) == {"Equifax", "Experian", "TransUnion"}
+        for result in profile.values():
+            assert result.name == "FICO Score 8"
+            assert 300 <= result.score <= 850
+
+
+def test_credit_score_profile_single_bureau_model(fake):
+    """Single-bureau model returns a single-entry dict."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(score_type="fico5")
+        assert set(profile.keys()) == {"Equifax"}
+        assert profile["Equifax"].name == "Equifax Beacon 5.0"
+        assert 334 <= profile["Equifax"].score <= 818
+
+
+def test_credit_score_profile_filter_providers(fake):
+    """Only requested providers are returned."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(
+            score_type="fico8", providers=["Equifax", "TransUnion"]
+        )
+        assert set(profile.keys()) == {"Equifax", "TransUnion"}
+
+
+def test_credit_score_profile_case_insensitive_providers(fake):
+    """Provider names are matched case-insensitively."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(
+            score_type="fico8", providers=["equifax", "EXPERIAN"]
+        )
+        assert set(profile.keys()) == {"Equifax", "Experian"}
+
+
+def test_credit_score_profile_invalid_provider(fake):
+    """Requesting a provider not available for the model raises ValueError."""
+    with pytest.raises(ValueError, match="not available"):
+        fake.credit_score_profile(score_type="fico5", providers=["TransUnion"])
+
+
+def test_credit_score_profile_nonexistent_score_type(fake):
+    with pytest.raises(KeyError):
+        fake.credit_score_profile(score_type="nonexistent")
+
+
+def test_credit_score_profile_with_tier(fake):
+    """Tier constrains scores to the right ballpark."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(score_type="fico8", tier="poor")
+        for result in profile.values():
+            # Base score is in poor range; jitter may push slightly outside
+            assert 275 <= result.score <= 604  # 300±25 to 579±25
+
+
+def test_credit_score_profile_with_tier_and_model(fake):
+    """Combined tier and model constraints work correctly."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(score_type="fico5", tier="exceptional")
+        assert set(profile.keys()) == {"Equifax"}
+        # fico5 range 334-818, exceptional 800-850 → base 800-818, jitter clamped to model
+        assert 775 <= profile["Equifax"].score <= 818
+
+
+def test_credit_score_profile_invalid_tier(fake):
+    with pytest.raises(ValueError, match="Unknown tier"):
+        fake.credit_score_profile(tier="nonexistent")
+
+
+def test_credit_score_profile_tier_no_overlap(fake):
+    """Tier with no overlap raises ValueError."""
+    from faker_credit_score import CreditScore, CreditScoreObject
+    CreditScore.credit_score_types["narrow_test"] = CreditScoreObject(
+        "Narrow Test", ("Test",), (600, 650)
+    )
+    try:
+        with pytest.raises(ValueError):
+            fake.credit_score_profile(score_type="narrow_test", tier="exceptional")
+    finally:
+        del CreditScore.credit_score_types["narrow_test"]
+
+
+def test_credit_score_profile_scores_correlated(fake):
+    """All scores in a profile should be within 50 points of each other."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(score_type="fico8")
+        scores = [r.score for r in profile.values()]
+        assert max(scores) - min(scores) <= 50
+
+
+def test_credit_score_profile_scores_within_model_range(fake):
+    """Jitter should never push scores outside the model's valid range."""
+    for _ in range(100):
+        profile = fake.credit_score_profile(score_type="fico5")
+        for result in profile.values():
+            assert 334 <= result.score <= 818


### PR DESCRIPTION
## Summary
- New method `credit_score_profile()` generates correlated credit scores across bureaus for the same person
- Base score + per-bureau jitter (±25 points) simulates real cross-bureau variance
- Supports `score_type`, `tier`, and `providers` parameters (case-insensitive provider matching)
- Individual bureau scores may naturally drift across tier boundaries
- 13 new tests, 100% coverage maintained (43 total)

### Usage
```python
fake.credit_score_profile()
# {'Equifax': CreditScoreResult(..., score=742),
#  'Experian': CreditScoreResult(..., score=738),
#  'TransUnion': CreditScoreResult(..., score=751)}

fake.credit_score_profile(score_type="fico8", providers=["equifax", "experian"], tier="good")
# {'Equifax': CreditScoreResult(..., score=712),
#  'Experian': CreditScoreResult(..., score=698)}
```

## Test plan
- [x] 13 new tests covering default, model-specific, single-bureau, provider filtering, case-insensitivity, error cases, correlation, and range clamping
- [x] 100% coverage
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)